### PR TITLE
added after_animation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Documentation can be found on the official project page: [http://www.buildintern
 
 *** Changelog ***
 
+HEAD
+
+	*Added after_animation callback
+
 3/15/11 - 3.1.3 Update (All editions)
 
 	*Added fix for images on IE failing to resize when loaded (update supersized.3.1.x.js)

--- a/slideshow/js/supersized.3.1.3.js
+++ b/slideshow/js/supersized.3.1.3.js
@@ -47,8 +47,11 @@
 			navigation              :   1,		//Slideshow controls on/off
 			thumbnail_navigation    :   0,		//Thumbnail navigation
 			slide_counter           :   1,		//Display slide numbers
-			slide_captions          :   1		//Slide caption (Pull from "title" in slides array)
+			slide_captions          :   1,		//Slide caption (Pull from "title" in slides array)
 			
+			//Callback functions
+			after_animation         :   null,	//Callback function to be exectued after the animation completes.  Called with the currentSlide number as an argument.
+			context                 :   this	//Scope in which to execute callback functions
     	};
 		
 		//Default elements
@@ -732,6 +735,11 @@
 			}
 			
 			resizenow();
+			
+			//If callback function is defined, execute the callback
+			if (options.after_animation){
+				options.after_animation.call(options.context, currentSlide);
+			}
 			
 		}
 		


### PR DESCRIPTION
I wanted to be able to execute code after the slideshow transition, so I added this callback to be executed on after the change.  It can be used like so:

```
$.supersized({
  slideshow: 1,
  ...
  after_animation: function(currentSlide){
    alert('You are now on slide number ' + currentSlide);
  }
});
```

I also added a `context` option, where the callback function will be executed in the scope of the provided object.  I was also trying to add an `after_load` callback for when the first image is displayed, but couldn't quite get it right.
