### PR TITLE
Fix for race condition between the Flickr API call and window load event

### DIFF
--- a/flickr/js/supersized.flickr.1.1.2.js
+++ b/flickr/js/supersized.flickr.1.1.2.js
@@ -114,7 +114,7 @@
 	    		break;
 	    		
 	    }
-    	
+		var flickrLoaded = false;
 		$.ajax({ //request to Flickr
 			type: 'GET',  
   			url: flickrURL,  
@@ -169,7 +169,7 @@
 				}
 				
 				/***End load initial images***/
-    			 
+				flickrLoaded = true;
     		}//End AJAX Callback 
     	 });
 
@@ -182,7 +182,19 @@
 			resizenow();
 		});
 		
-		$(window).load(function(){
+		$(window).load(function() {
+			ready();
+		});
+		
+		var ready = function(){
+			if(flickrLoaded) {
+				loadFunc();
+			} else {
+				setTimeout(ready, 100);
+			}
+		};
+		
+		var loadFunc = function(){
 			
 			$('#supersized-loader').hide();		//Hide loading animation
 			element.fadeIn('fast');				//Fade in background


### PR DESCRIPTION
I've been using supersized (great plugin, btw) on an HTML5 website and noticed that certain browsers (specifically IE9 in standards mode) appear to have a race condition between the Flickr API call returning and the window load event firing.

The result was that in IE9 in standards mode you would be stuck in the "loading" phase until you clicked next/previous slide.

My fix isn't particularly pretty, but it was the smallest change I could come up with that worked properly in all the browsers I've tested (IE9, FireFox 3.6/4/5, Chrome 12/13).
