### PR TITLE
When using numeric slide links its better to start numbers with 1 instead 0.

### DIFF
--- a/slideshow/js/supersized.3.2.7.js
+++ b/slideshow/js/supersized.3.2.7.js
@@ -58,7 +58,7 @@
 				//Determine slide link content
 				switch(base.options.slide_links){
 					case 'num':
-						markerContent = thisSlide;
+						markerContent = thisSlide + 1;
 						break;
 					case 'name':
 						markerContent = base.options.slides[thisSlide].title;


### PR DESCRIPTION
Also on your [documentation](http://buildinternet.com/project/supersized/docs.html) page it mentions value for variable `slide_links` should be "number" to get number links but code actually checks for value to be "num".
