### PR TITLE
Update flickr/js/supersized.flickr.1.1.2.js

### DIFF
--- a/flickr/js/supersized.flickr.1.1.2.js
+++ b/flickr/js/supersized.flickr.1.1.2.js
@@ -167,7 +167,7 @@
     			    //create image urls
     			    var photoURL = 'http://farm' + item.farm + '.static.flickr.com/' + item.server + '/' + item.id + '_' + item.secret + '_' + options.image_size + '.jpg';
     			    var thumbURL = 'http://farm' + item.farm + '.static.flickr.com/' + item.server + '/' + item.id + '_' + item.secret + '_t.jpg';
-    			   	var	photoLink = "http://www.flickr.com/photos/" + item.owner + "/" + item.id + "/";
+    			   	var	photoLink = "http://www.flickr.com/photos/" + data.photoset.owner + "/" + item.id + "/";
     			   	
     			    if (i == 0){
     			    	options.slides.splice(0,1,{ image : photoURL, thumb : thumbURL, title : item.title , url : photoLink });


### PR DESCRIPTION
Changed line 170 from 'item.owner' to 'data.photoset.owner' because that's where the Owner ID is in Flickr's JSON response.
If this line isn't changed, then supersized creates URLs images with 'undefined' as the USER ID.
