### PR TITLE
Bug fix for data.photoset.owner null

### DIFF
--- a/flickr/js/supersized.flickr.1.1.2.js
+++ b/flickr/js/supersized.flickr.1.1.2.js
@@ -560,7 +560,7 @@
 						if ((browserheight/browserwidth) > ratio){
 							options.fit_landscape && ratio <= 1 ? resizeWidth() : resizeHeight();	//If landscapes are set to fit
 						} else {
-							options.fit_portrait && ratio > 1 ? resizeHeight() : resizeWidth();		//If portraits are set to fit
+							options.fit_portrait && ratio >= 1 ? resizeHeight() : resizeWidth();		//If portraits are set to fit
 						}
 						
 					}

--- a/flickr/js/supersized.flickr.1.1.2.js
+++ b/flickr/js/supersized.flickr.1.1.2.js
@@ -167,7 +167,7 @@
     			    //create image urls
     			    var photoURL = 'http://farm' + item.farm + '.static.flickr.com/' + item.server + '/' + item.id + '_' + item.secret + '_' + options.image_size + '.jpg';
     			    var thumbURL = 'http://farm' + item.farm + '.static.flickr.com/' + item.server + '/' + item.id + '_' + item.secret + '_t.jpg';
-    			   	var	photoLink = "http://www.flickr.com/photos/" + data.photoset.owner + "/" + item.id + "/";
+    			    var photoLink = "http://www.flickr.com/photos/" + (data.photoset ? data.photoset.owner : item.owner) + "/" + item.id + "/";
     			   	
     			    if (i == 0){
     			    	options.slides.splice(0,1,{ image : photoURL, thumb : thumbURL, title : item.title , url : photoLink });


### PR DESCRIPTION
A previous change (pull request #66) appears to have introduced a bug
for user based photos, while fixing a bug for set based photos. This now
uses data.photoset.owner when data.photoset exists, otherwise, reverts
to item.owner.
