### PR TITLE
Abort keyboard navigation if the active element on the page is an input or a textarea

### DIFF
--- a/slideshow/js/supersized.3.2.7.js
+++ b/slideshow/js/supersized.3.2.7.js
@@ -215,6 +215,7 @@
 				$(document.documentElement).keyup(function (event) {
 				
 					if(vars.in_animation) return false;		// Abort if currently animating
+					if($(document.activeElement).is("input, textarea")) return false; // Abort if active element is an input or a textarea.
 					
 					// Left Arrow or Down Arrow
 					if ((event.keyCode == 37) || (event.keyCode == 40)) {


### PR DESCRIPTION
This is a great library, but I had a background slideshow with a foreground contact form and every time I moved the cursor in my textarea the background changed image.

I added line 218 to abort the keyboard navigation if the active element on the page is an input or a textarea element.

You can add it to your repository if you want.
