### PR TITLE
Supersized ready event

### DIFF
--- a/core/js/supersized.core.3.2.1.js
+++ b/core/js/supersized.core.3.2.1.js
@@ -16,6 +16,7 @@
 	----------------------------*/
 	$(document).ready(function() {
 		$('body').append('<div id="supersized-loader"></div><div id="supersized"></div>');
+		$(document).trigger( 'supersized-ready' );
 	});
     
     


### PR DESCRIPTION
Fire `supersized-ready` upon `#supersized-loader` creation so scripts could bind just after that.
