### PR TITLE
fix for memory leak when DOM object not emptied

### DIFF
--- a/slideshow/js/supersized.3.2.7.js
+++ b/slideshow/js/supersized.3.2.7.js
@@ -516,7 +516,8 @@
 				
 			}
 			
-			
+			// Clean up memory leak
+			$(prevslide).empty();
 			
 			/*-----End Load Image-----*/
 			


### PR DESCRIPTION
Without this fix, the slideshow used to crash on a Google TV (low on memory) after running for a couple days, or would crash much more quickly if using more than 27 images. Since implementing this fix, the slideshow has been running without fail for weeks.
